### PR TITLE
Added taurus ansible task

### DIFF
--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -39,3 +39,4 @@
       - wkhtmltopdf
       - bash-completion
       - autojump
+      - taurus

--- a/ansible/roles/taurus/tasks/main.yml
+++ b/ansible/roles/taurus/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+  - name: update
+    apt:
+      upgrade=dist
+      autoremove=yes
+      update_cache=yes
+
+  - name: install packages
+    apt:
+      name={{ item }}
+      state=present
+      autoremove=yes
+    with_items:
+      - python
+      - default-jre-headless
+      - python-tk
+      - python-pip
+      - python-dev
+      - libxml2-dev
+      - libxslt-dev
+      - zlib1g-dev
+
+  - name: install taurus
+    pip:
+      name=bzt

--- a/ansible/roles/taurus/tasks/main.yml
+++ b/ansible/roles/taurus/tasks/main.yml
@@ -1,10 +1,4 @@
 ---
-  - name: update
-    apt:
-      upgrade=dist
-      autoremove=yes
-      update_cache=yes
-
   - name: install packages
     apt:
       name={{ item }}

--- a/development-environment-base.json
+++ b/development-environment-base.json
@@ -50,7 +50,8 @@
           "./ansible/roles/newrelic",
           "./ansible/roles/bosh",
           "./ansible/roles/fly",
-          "./ansible/roles/groovy"
+          "./ansible/roles/groovy",
+          "./ansible/roles/taurus"
         ]
      },
      {


### PR DESCRIPTION
Added taurus ansible task

This ansible task installs all the pre-requisite python libraries required for taurus, along with the taurus python plugin. This allows taurus tests to be ran locally