### PR TITLE
Moved taurus task to correct file

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -42,3 +42,4 @@
     - bosh
     - fly
     - groovy
+    - taurus

--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -39,4 +39,3 @@
       - wkhtmltopdf
       - bash-completion
       - autojump
-      - taurus


### PR DESCRIPTION
Removed the taurus task from developer_packages task list and added it
to main list

It was incorrectly added to the wrong file, which causes the packer build to fail