### PR TITLE
Unique location for intellij community installation

### DIFF
--- a/ansible/roles/intellij/tasks/main.yml
+++ b/ansible/roles/intellij/tasks/main.yml
@@ -1,25 +1,25 @@
 ---
   - name: create intelli directory
     file:
-      path=/opt/intellij/{{ intellij_version }}/
+      path=/opt/intellij/IC/{{ intellij_version }}/
       state=directory
       mode=0777
 
   - name: download checksum
     get_url:
       url: https://download.jetbrains.com/idea/ideaIC-{{ intellij_version }}-no-jdk.tar.gz.sha256
-      dest: /opt/intellij/intellij.sha256
+      dest: /opt/intellij/IC/intellij.sha256
 
   - name: download the file
     get_url:
       url="https://download.jetbrains.com/idea/ideaIC-{{ intellij_version }}-no-jdk.tar.gz"
-      dest="/opt/intellij/"
-      checksum="sha256:{{ lookup('file', '/opt/intellij/intellij.sha256')[0:64] }}"
+      dest="/opt/intellij/IC/"
+      checksum="sha256:{{ lookup('file', '/opt/intellij/IC/intellij.sha256')[0:64] }}"
 
   - name: untar
     unarchive:
-      src: "/opt/intellij/ideaIC-{{ intellij_version }}-no-jdk.tar.gz"
-      dest: "/opt/intellij/{{ intellij_version }}"
+      src: "/opt/intellij/IC/ideaIC-{{ intellij_version }}-no-jdk.tar.gz"
+      dest: "/opt/intellij/IC/{{ intellij_version }}"
       extra_opts: [--strip-components=1]
 
   - name: update directory permissions
@@ -32,7 +32,7 @@
 
   - name: add symlink
     file:
-      src="/opt/intellij/{{ intellij_version }}/bin/idea.sh"
+      src="/opt/intellij/IC/{{ intellij_version }}/bin/idea.sh"
       dest="/usr/bin/intellij"
       state=link
 
@@ -47,7 +47,7 @@
     replace:
       dest=/tmp/jetbrains-idea-ce.desktop
       regexp='^(.*)REPLACE_INTELLIJ_PATH(.*)$'
-      replace='\1/opt/intellij/{{ intellij_version }}\2'
+      replace='\1/opt/intellij/IC/{{ intellij_version }}\2'
 
   - name: ensure desktop shortcut directory exists
     file:
@@ -62,10 +62,10 @@
 
   - name: remove binaries
     file:
-      path=/opt/intellij/ideaIC-{{ intellij_version }}-no-jdk.tar.gz
+      path=/opt/intellij/IC/ideaIC-{{ intellij_version }}-no-jdk.tar.gz
       state=absent
 
   - name: remove checksum
     file:
-      path=/opt/intellij/intellij.sha256
+      path=/opt/intellij/IC/intellij.sha256
       state=absent


### PR DESCRIPTION
A specific location is required for community edition to ensure further
provisioning of base box, by installing ultimate for instance, can be
simplified.  This will also ensure that if further provisioning requires
community to be deleted, that it can be uniquely identified