### PR TITLE
Specify gcloud version to 185.0.0

### DIFF
--- a/ansible/roles/gcloud/tasks/main.yml
+++ b/ansible/roles/gcloud/tasks/main.yml
@@ -15,5 +15,4 @@
   - name: Install cli
     apt:
       name: google-cloud-sdk=185.0.0-0
-      state: latest
       update-cache: yes

--- a/ansible/roles/gcloud/tasks/main.yml
+++ b/ansible/roles/gcloud/tasks/main.yml
@@ -14,6 +14,6 @@
 
   - name: Install cli
     apt:
-      name: google-cloud-sdk
+      name: google-cloud-sdk=185.0.0-0
       state: latest
       update-cache: yes


### PR DESCRIPTION
The latest release, 186.0.0, has known bugs. So hardcoding the previous
working version to ensure gcloud init works successfully.