### PR TITLE
change google-cloud-sdk to latest version

### DIFF
--- a/ansible/roles/gcloud/tasks/main.yml
+++ b/ansible/roles/gcloud/tasks/main.yml
@@ -14,5 +14,6 @@
 
   - name: Install cli
     apt:
-      name: google-cloud-sdk=185.0.0-0
+      name: google-cloud-sdk
+      state: latest
       update-cache: yes


### PR DESCRIPTION
google-cloud-sdk 187.0.0 tested successfully so returning configuration to take latest release (as 186.0.0 was a bad release)