### PR TITLE
Remove unsupported parameter from pip module

### DIFF
--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -40,3 +40,10 @@
       - bash-completion
       - autojump
       - nano
+
+  - name: Install Python package(s)
+    pip:
+      name={{ item }}
+      state=present
+    with_items:
+      - json2yaml


### PR DESCRIPTION
Although `become` is shown in the documentation, it causes an error. Removed it.