### PR TITLE
Install json2yaml package

### DIFF
--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -40,3 +40,11 @@
       - bash-completion
       - autojump
       - nano
+
+  - name: Install Python package(s)
+    pip:
+      name={{ item }}
+      state=present
+    become: true
+    with_items:
+      - json2yaml


### PR DESCRIPTION
This change enables installation of Python packages via pip. It has correct indentation for `become` parameter this time.