### PR TITLE
Change installation order

### DIFF
--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -40,11 +40,12 @@
       - bash-completion
       - autojump
       - nano
+      - python
+      - python-pip
 
   - name: Install Python package(s)
     pip:
       name={{ item }}
       state=present
-    become: true
     with_items:
       - json2yaml

--- a/ansible/roles/taurus/tasks/main.yml
+++ b/ansible/roles/taurus/tasks/main.yml
@@ -5,10 +5,8 @@
       state=present
       autoremove=yes
     with_items:
-      - python
       - default-jre-headless
       - python-tk
-      - python-pip
       - python-dev
       - libxml2-dev
       - libxslt-dev


### PR DESCRIPTION
In order to install json2yaml, we need python and python-pip packages installed
first. Removed them from `taurus` role and moved them into `developer_packages`
role.