### PR TITLE
Install libcurl

### DIFF
--- a/ansible/roles/bosh/tasks/main.yml
+++ b/ansible/roles/bosh/tasks/main.yml
@@ -19,6 +19,7 @@
         - libyaml-dev
         - libsqlite3-dev
         - sqlite3
+        - libcurl4-openssl-dev
 
   - name: download bosh-cli
     get_url:


### PR DESCRIPTION
Ruby gem installation fails for ovirt-engine-sdk without it