### PR TITLE
Remove apt update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ env:
   - ATLAS_TOKEN=dummytoken
 
 language: generic
-before_install:
-  - sudo apt-get -qq update
 
 install:
   - wget https://releases.hashicorp.com/packer/1.3.0/packer_1.3.0_linux_amd64.zip -O ./packer.zip


### PR DESCRIPTION
As packer installer is downloaded directly, there's no need to update apt on each build