### PR TITLE
Replace myspell with hunspell

### DIFF
--- a/ansible/roles/atom/tasks/main.yml
+++ b/ansible/roles/atom/tasks/main.yml
@@ -6,6 +6,6 @@
 
   - name: "install en_gb dictionary"
     apt:
-      name=myspell-en-gb
+      name=hunspell-en-gb
       state=present
       autoremove=yes


### PR DESCRIPTION
In preparation for ubuntu 18.04, myspell is superceded by hunspell. Both are compatible