### PR TITLE
Remove deprecated apt loop

### DIFF
--- a/ansible/roles/bosh/tasks/main.yml
+++ b/ansible/roles/bosh/tasks/main.yml
@@ -1,24 +1,24 @@
 ---
   - name: install dependencies
     apt:
-        name={{ item }}
-        state=present
-        autoremove=yes
-    with_items:
-        - build-essential
-        - zlibc
-        - zlib1g-dev
-        - ruby
-        - ruby-dev
-        - openssl
-        - libxslt-dev
-        - libxml2-dev
-        - libssl-dev
-        - libreadline6-dev
-        - libyaml-dev
-        - libsqlite3-dev
-        - sqlite3
-        - libcurl4-openssl-dev
+      name: "{{ packages }}"
+      autoremove: yes
+    vars:
+      packages:
+      - build-essential
+      - zlibc
+      - zlib1g-dev
+      - ruby
+      - ruby-dev
+      - openssl
+      - libxslt-dev
+      - libxml2-dev
+      - libssl-dev
+      - libreadline6-dev
+      - libyaml-dev
+      - libsqlite3-dev
+      - sqlite3
+      - libcurl4-openssl-dev
 
   - name: download bosh-cli
     get_url:

--- a/ansible/roles/desktop/tasks/main.yml
+++ b/ansible/roles/desktop/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
   - name: install packages
     apt:
-      name: "{{ item }}"
-    with_items:
-      - xubuntu-core
+      name: xubuntu-core

--- a/ansible/roles/developer_packages/tasks/main.yml
+++ b/ansible/roles/developer_packages/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
   - name: update
     apt:
-      upgrade=dist
-      autoremove=yes
-      update_cache=yes
+      upgrade: dist
+      autoremove: yes
+      update_cache: yes
 
   - name: install packages
     apt:
-      name={{ item }}
-      state=present
-      autoremove=yes
-    with_items:
+      name: "{{ packages }}"
+      autoremove: yes
+    vars:
+      packages:
       - putty-tools
       - dos2unix
       - wmctrl

--- a/ansible/roles/git/tasks/main.yml
+++ b/ansible/roles/git/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
   - name: add git-core ppa
     apt_repository:
-      repo='ppa:git-core/ppa'
+      repo: 'ppa:git-core/ppa'
 
   - name: update
     apt:
-      upgrade=dist
-      autoremove=yes
-      update_cache=yes
+      upgrade: dist
+      autoremove: yes
+      update_cache: yes
 
   - name: install git
     apt:
-      name={{ item }}
-      state=present
-      autoremove=yes
-    with_items:
+      name: "{{ packages }}"
+      autoremove: yes
+    vars:
+      packages:
       - gitk
       - git-gui
 

--- a/ansible/roles/taurus/tasks/main.yml
+++ b/ansible/roles/taurus/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
   - name: install packages
     apt:
-      name={{ item }}
-      state=present
-      autoremove=yes
-    with_items:
+      name: "{{ packages }}"
+      autoremove: yes
+    vars:
+      packages:
       - default-jre-headless
       - python-tk
       - python-dev
@@ -14,4 +14,4 @@
 
   - name: install taurus
     pip:
-      name=bzt
+      name: bzt


### PR DESCRIPTION
Invoking 'apt' only once while using a loop via squash_actions is deprecated and will be removed in ansible 2.11.

Tidied up edited files to match the recommended ansible config (using `:` instead of `=`).