### PR TITLE
Specify jdk version in taurus

### DIFF
--- a/ansible/roles/intellij/tasks/main.yml
+++ b/ansible/roles/intellij/tasks/main.yml
@@ -89,10 +89,3 @@
     file:
       path: /opt/intellij/IC/intellij.sha256
       state: absent
-
-  - name: ensure java 8 is set as default
-    alternatives:
-      link: /usr/bin/java
-      name: java
-      path: /usr/lib/jvm/java-8-openjdk-amd64/bin/java
-      priority: 100

--- a/ansible/roles/taurus/tasks/main.yml
+++ b/ansible/roles/taurus/tasks/main.yml
@@ -5,7 +5,8 @@
       autoremove: yes
     vars:
       packages:
-      - default-jre-headless
+      - openjdk-8-jre-headless
+      - java-common
       - python-tk
       - python-dev
       - libxml2-dev


### PR DESCRIPTION
No longer need to manually set the jdk version for intellij as the jre11 will not be present