### PR TITLE
Download intellij with the bundled JDK

### DIFF
--- a/ansible/roles/intellij/tasks/main.yml
+++ b/ansible/roles/intellij/tasks/main.yml
@@ -29,18 +29,18 @@
 
   - name: download checksum
     get_url:
-      url: "https://download.jetbrains.com/idea/ideaIC-{{ intellij_version }}-no-jdk.tar.gz.sha256"
+      url: "https://download.jetbrains.com/idea/ideaIC-{{ intellij_version }}.tar.gz.sha256"
       dest: /opt/intellij/IC/intellij.sha256
 
   - name: download the file
     get_url:
-      url: "https://download.jetbrains.com/idea/ideaIC-{{ intellij_version }}-no-jdk.tar.gz"
+      url: "https://download.jetbrains.com/idea/ideaIC-{{ intellij_version }}.tar.gz"
       dest: "/opt/intellij/IC/"
       checksum: "sha256:{{ lookup('file', '/opt/intellij/IC/intellij.sha256')[0:64] }}"
 
   - name: untar
     unarchive:
-      src: "/opt/intellij/IC/ideaIC-{{ intellij_version }}-no-jdk.tar.gz"
+      src: "/opt/intellij/IC/ideaIC-{{ intellij_version }}.tar.gz"
       dest: "/opt/intellij/IC/{{ intellij_version }}"
       extra_opts: [--strip-components=1]
 
@@ -82,7 +82,7 @@
 
   - name: remove binaries
     file:
-      path: "/opt/intellij/IC/ideaIC-{{ intellij_version }}-no-jdk.tar.gz"
+      path: "/opt/intellij/IC/ideaIC-{{ intellij_version }}.tar.gz"
       state: absent
 
   - name: remove checksum


### PR DESCRIPTION
Improves performance by making use of the custom openjdk that Jetbrains develop to run IntelliJ