### PR TITLE
Revert "Rollback maven to 3.5.4 (#213)"

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -2,7 +2,7 @@
 - hosts: all
   vars:
     cf_cli_version: "6.40.1"
-    maven_version: "3.5.4"
+    maven_version: "3.6.0"
     atom_version: "1.26.1"
     gradle_version: "4.10.2"
     go_version: "1.11.2"


### PR DESCRIPTION
This reverts commit 9593a30e82f96aa9d95968d52e11056f7887766b.

Looks like the downgrade won't help us