### PR TITLE
 Move roles from private image to base

### DIFF
--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -24,14 +24,18 @@
   become: yes
   roles:
     - developer_packages
+    - pip_packages
     - git
     - atom
     - geerlingguy.docker
     - cf_cli
     - maven
     - gradle
+    - java
     - intellij
     - desktop
+    - lightdm
+    - power_management
     - go
     - postman
     - compliance_masonry
@@ -46,3 +50,5 @@
     - hub
     - lastpass
     - dotnet
+    - vi
+    - bash_alias

--- a/ansible/roles/bash_alias/tasks/main.yml
+++ b/ansible/roles/bash_alias/tasks/main.yml
@@ -7,6 +7,5 @@
       create: yes
       line: "alias {{item.name}}='{{item.command}}'"
     with_items:
-      - { name: 'pman', command: 'unset HTTPS_PROXY && unset HTTP_PROXY && /opt/Postman/Postman --disable-gpu'}
       - { name: 'syncmaster', command: 'git checkout master; git fetch --all; git merge --ff-only upstream/master; git push; git checkout -'}
       - { name: 'pr', command: 'git push origin HEAD -u && hub pull-request'}

--- a/ansible/roles/bash_alias/tasks/main.yml
+++ b/ansible/roles/bash_alias/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+  - name: Add command aliases
+    lineinfile:
+      path: /home/vagrant/.bash_aliases
+      owner: root
+      state: present
+      create: yes
+      line: "alias {{item.name}}='{{item.command}}'"
+    with_items:
+      - { name: 'pman', command: 'unset HTTPS_PROXY && unset HTTP_PROXY && /opt/Postman/Postman --disable-gpu'}
+      - { name: 'syncmaster', command: 'git checkout master; git fetch --all; git merge --ff-only upstream/master; git push; git checkout -'}
+      - { name: 'pr', command: 'git push origin HEAD -u && hub pull-request'}

--- a/ansible/roles/java/tasks/main.yml
+++ b/ansible/roles/java/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: ensure java 8 is set as default
+  alternatives:
+    link: /usr/bin/java
+    name: java
+    path: /usr/lib/jvm/java-8-openjdk-amd64/bin/java
+    priority: 100

--- a/ansible/roles/lightdm/files/lightdm.conf
+++ b/ansible/roles/lightdm/files/lightdm.conf
@@ -1,0 +1,4 @@
+[Seat:*]
+autologin-guest=false
+autologin-user=vagrant
+autologin-user-timeout=0

--- a/ansible/roles/lightdm/tasks/main.yml
+++ b/ansible/roles/lightdm/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+  - name: copy autologin config
+    copy:
+      src: lightdm.conf
+      dest: /etc/lightdm/lightdm.conf
+

--- a/ansible/roles/pip_packages/tasks/main.yml
+++ b/ansible/roles/pip_packages/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: install pip3
+  apt:
+    name: python3-pip
+
+- name: install latest python 2 packages
+  pip:
+    name: ['pylint', 'requests']
+    state: latest
+
+- name: install latest python 3 packages
+  pip:
+    executable: pip3
+    name: pylint
+    state: latest

--- a/ansible/roles/power_management/files/.xscreensaver
+++ b/ansible/roles/power_management/files/.xscreensaver
@@ -1,0 +1,281 @@
+# XScreenSaver Preferences File
+# Written by xscreensaver-demo 5.36 for vagrant on Tue Oct 23 07:47:26 2018.
+# https://www.jwz.org/xscreensaver/
+
+timeout:	0:10:00
+cycle:		0:10:00
+lock:		False
+lockTimeout:	0:00:00
+passwdTimeout:	0:00:30
+visualID:	default
+installColormap:    True
+verbose:	False
+timestamp:	True
+splash:		True
+splashDuration:	0:00:05
+demoCommand:	xscreensaver-demo
+prefsCommand:	xscreensaver-demo -prefs
+nice:		10
+memoryLimit:	0
+fade:		True
+unfade:		False
+fadeSeconds:	0:00:03
+fadeTicks:	20
+captureStderr:	True
+ignoreUninstalledPrograms:False
+font:		*-medium-r-*-140-*-m-*
+dpmsEnabled:	False
+dpmsQuickOff:	False
+dpmsStandby:	2:00:00
+dpmsSuspend:	2:00:00
+dpmsOff:	4:00:00
+grabDesktopImages:  False
+grabVideoFrames:    False
+chooseRandomImages: False
+imageDirectory:	
+
+mode:		off
+selected:	-1
+
+textMode:	url
+textLiteral:	XScreenSaver
+textFile:	
+textProgram:	fortune
+textURL:	http://feeds.feedburner.com/ubuntu-news
+
+programs:								      \
+				maze -root				    \n\
+- GL: 				superquadrics -root			    \n\
+				attraction -root			    \n\
+				blitspin -root				    \n\
+				greynetic -root				    \n\
+				helix -root				    \n\
+				hopalong -root				    \n\
+				imsmap -root				    \n\
+-				noseguy -root				    \n\
+-				pyro -root				    \n\
+				qix -root				    \n\
+-				rocks -root				    \n\
+				rorschach -root				    \n\
+				decayscreen -root			    \n\
+				flame -root				    \n\
+				halo -root				    \n\
+				slidescreen -root			    \n\
+				pedal -root				    \n\
+				bouboule -root				    \n\
+-				braid -root				    \n\
+				coral -root				    \n\
+				deco -root				    \n\
+				drift -root				    \n\
+-				fadeplot -root				    \n\
+				galaxy -root				    \n\
+				goop -root				    \n\
+				grav -root				    \n\
+				ifs -root				    \n\
+				unicode -root				    \n\
+- GL: 				jigsaw -root				    \n\
+				julia -root				    \n\
+-				kaleidescope -root			    \n\
+- GL: 				moebius -root				    \n\
+				moire -root				    \n\
+- GL: 				morph3d -root				    \n\
+				mountain -root				    \n\
+				munch -root				    \n\
+				penrose -root				    \n\
+- GL: 				pipes -root				    \n\
+				rd-bomb -root				    \n\
+- GL: 				rubik -root				    \n\
+-				sierpinski -root			    \n\
+				slip -root				    \n\
+- GL: 				sproingies -root			    \n\
+				starfish -root				    \n\
+				strange -root				    \n\
+				swirl -root				    \n\
+				triangle -root				    \n\
+				xjack -root				    \n\
+				xlyap -root				    \n\
+- GL: 				atlantis -root				    \n\
+				bsod -root				    \n\
+- GL: 				bubble3d -root				    \n\
+- GL: 				cage -root				    \n\
+-				crystal -root				    \n\
+				cynosure -root				    \n\
+				discrete -root				    \n\
+				distort -root				    \n\
+				epicycle -root				    \n\
+				flow -root				    \n\
+- GL: 				glplanet -root				    \n\
+				interference -root			    \n\
+				kumppa -root				    \n\
+- GL: 				lament -root				    \n\
+				moire2 -root				    \n\
+- GL: 				sonar -root				    \n\
+- GL: 				stairs -root				    \n\
+				truchet -root				    \n\
+-				vidwhacker -root			    \n\
+				blaster -root				    \n\
+				bumps -root				    \n\
+				ccurve -root				    \n\
+				compass -root				    \n\
+				deluxe -root				    \n\
+-				demon -root				    \n\
+- GL: 				extrusion -root				    \n\
+-				loop -root				    \n\
+				penetrate -root				    \n\
+				petri -root				    \n\
+				phosphor -root				    \n\
+- GL: 				pulsar -root				    \n\
+				ripples -root				    \n\
+				shadebobs -root				    \n\
+- GL: 				sierpinski3d -root			    \n\
+				spotlight -root				    \n\
+				squiral -root				    \n\
+				wander -root				    \n\
+-				webcollage -root			    \n\
+				xflame -root				    \n\
+				xmatrix -root				    \n\
+- GL: 				gflux -root				    \n\
+-				nerverot -root				    \n\
+				xrayswarm -root				    \n\
+				xspirograph -root			    \n\
+- GL: 				circuit -root				    \n\
+- GL: 				dangerball -root			    \n\
+- GL: 				engine -root				    \n\
+- GL: 				flipscreen3d -root			    \n\
+- GL: 				gltext -root				    \n\
+- GL: 				menger -root				    \n\
+- GL: 				molecule -root				    \n\
+				rotzoomer -root				    \n\
+				speedmine -root				    \n\
+- GL: 				starwars -root				    \n\
+- GL: 				stonerview -root			    \n\
+				vermiculate -root			    \n\
+				whirlwindwarp -root			    \n\
+				zoom -root				    \n\
+				anemone -root				    \n\
+				apollonian -root			    \n\
+- GL: 				boxed -root				    \n\
+- GL: 				cubenetic -root				    \n\
+- GL: 				endgame -root				    \n\
+				euler2d -root				    \n\
+				fluidballs -root			    \n\
+- GL: 				flurry -root				    \n\
+- GL: 				glblur -root				    \n\
+- GL: 				glsnake -root				    \n\
+				halftone -root				    \n\
+- GL: 				juggler3d -root				    \n\
+- GL: 				lavalite -root				    \n\
+-				polyominoes -root			    \n\
+- GL: 				queens -root				    \n\
+- GL: 				sballs -root				    \n\
+- GL: 				spheremonics -root			    \n\
+-				thornbird -root				    \n\
+				twang -root				    \n\
+- GL: 				antspotlight -root			    \n\
+				apple2 -root				    \n\
+- GL: 				atunnel -root				    \n\
+				barcode -root				    \n\
+- GL: 				blinkbox -root				    \n\
+- GL: 				blocktube -root				    \n\
+- GL: 				bouncingcow -root			    \n\
+				cloudlife -root				    \n\
+- GL: 				cubestorm -root				    \n\
+				eruption -root				    \n\
+- GL: 				flipflop -root				    \n\
+- GL: 				flyingtoasters -root			    \n\
+				fontglide -root				    \n\
+- GL: 				gleidescope -root			    \n\
+- GL: 				glknots -root				    \n\
+- GL: 				glmatrix -root				    \n\
+- GL: 				glslideshow -root			    \n\
+- GL: 				hypertorus -root			    \n\
+- GL: 				jigglypuff -root			    \n\
+				metaballs -root				    \n\
+- GL: 				mirrorblob -root			    \n\
+				piecewise -root				    \n\
+- GL: 				polytopes -root				    \n\
+				pong -root				    \n\
+				popsquares -root			    \n\
+- GL: 				surfaces -root				    \n\
+				xanalogtv -root				    \n\
+				abstractile -root			    \n\
+				anemotaxis -root			    \n\
+- GL: 				antinspect -root			    \n\
+				fireworkx -root				    \n\
+				fuzzyflakes -root			    \n\
+				interaggregate -root			    \n\
+				intermomentary -root			    \n\
+				memscroller -root			    \n\
+- GL: 				noof -root				    \n\
+				pacman -root				    \n\
+- GL: 				pinion -root				    \n\
+- GL: 				polyhedra -root				    \n\
+- GL: 				providence -root			    \n\
+				substrate -root				    \n\
+				wormhole -root				    \n\
+- GL: 				antmaze -root				    \n\
+- GL: 				boing -root				    \n\
+				boxfit -root				    \n\
+- GL: 				carousel -root				    \n\
+				celtic -root				    \n\
+- GL: 				crackberg -root				    \n\
+- GL: 				cube21 -root				    \n\
+				fiberlamp -root				    \n\
+- GL: 				fliptext -root				    \n\
+- GL: 				glhanoi -root				    \n\
+- GL: 				tangram -root				    \n\
+- GL: 				timetunnel -root			    \n\
+- GL: 				glschool -root				    \n\
+- GL: 				topblock -root				    \n\
+- GL: 				cubicgrid -root				    \n\
+				cwaves -root				    \n\
+- GL: 				gears -root				    \n\
+- GL: 				glcells -root				    \n\
+- GL: 				lockward -root				    \n\
+				m6502 -root				    \n\
+- GL: 				moebiusgears -root			    \n\
+- GL: 				voronoi -root				    \n\
+- GL: 				hypnowheel -root			    \n\
+- GL: 				klein -root				    \n\
+-				lcdscrub -root				    \n\
+- GL: 				photopile -root				    \n\
+- GL: 				skytentacles -root			    \n\
+- GL: 				rubikblocks -root			    \n\
+- GL: 				companioncube -root			    \n\
+- GL: 				hilbert -root				    \n\
+- GL: 				tronbit -root				    \n\
+- GL: 				geodesic -root				    \n\
+				hexadrop -root				    \n\
+- GL: 				kaleidocycle -root			    \n\
+- GL: 				quasicrystal -root			    \n\
+- GL: 				unknownpleasures -root			    \n\
+				binaryring -root			    \n\
+- GL: 				cityflow -root				    \n\
+- GL: 				geodesicgears -root			    \n\
+- GL: 				projectiveplane -root			    \n\
+- GL: 				romanboy -root				    \n\
+				tessellimage -root			    \n\
+- GL: 				winduprobot -root			    \n\
+- GL: 				splitflap -root				    \n\
+- GL: 				cubestack -root				    \n\
+- GL: 				cubetwist -root				    \n\
+- GL: 				discoball -root				    \n\
+- GL: 				dymaxionmap -root			    \n\
+- GL: 				energystream -root			    \n\
+- GL: 				hexstrut -root				    \n\
+- GL: 				hydrostat -root				    \n\
+- GL: 				raverhoop -root				    \n\
+- GL: 				splodesic -root				    \n\
+- GL: 				unicrud -root				    \n\
+
+
+pointerPollTime:    0:00:05
+pointerHysteresis:  10
+windowCreationTimeout:0:00:30
+initialDelay:	0:00:00
+GetViewPortIsFullOfLies:False
+procInterrupts:	True
+xinputExtensionDev: False
+overlayStderr:	True
+authWarningSlack:   20
+

--- a/ansible/roles/power_management/tasks/main.yml
+++ b/ansible/roles/power_management/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+  - name: copy screensaver settings
+    copy:
+      src: .xscreensaver
+      dest: /home/vagrant/.xscreensaver

--- a/ansible/roles/vi/files/vimrc
+++ b/ansible/roles/vi/files/vimrc
@@ -1,0 +1,27 @@
+ " Indent automatically depending on filetype
+filetype indent on
+set autoindent
+
+" Turn on line numbering. Turn it off with set nonu
+set number
+
+" Set the tap spaces to 4 and expand to spaces
+set tabstop=4 softtabstop=0 expandtab shiftwidth=4
+
+" Set syntax on
+syntax on
+
+" Case insensitive search
+set ic
+
+" Highlight search
+set hls
+
+" Wrap text instead of being on one line
+set lbr
+
+" Change colorscheme from default to delek
+colorscheme delek
+
+" Limit line length for git commit messages
+au FileType gitcommit set tw=70

--- a/ansible/roles/vi/tasks/main.yml
+++ b/ansible/roles/vi/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+  - name: Create vim directory
+    file:
+      path=/home/vagrant/{{ item.dir }}
+      state=directory
+      owner=vagrant
+      group=vagrant
+      mode=0775
+    with_items:
+    - { dir: '.vim' }
+
+  - name: Creates directory
+    file:
+      path=/home/vagrant/.vim/{{ item.dir }}
+      state=directory
+      owner=vagrant
+      group=vagrant
+      mode=0775
+    with_items:
+    - { dir: 'ftdetect' }
+    - { dir: 'indent' }
+    - { dir: 'syntax' }
+
+  - name: copy scripts to workspace
+    copy:
+      src={{ item.src }}
+      dest={{ item.dest }}
+      owner=vagrant
+      group=vagrant
+      mode=0775
+    with_items:
+    - { src: 'vimrc', dest: '/home/vagrant/.vimrc' }
+
+  - name: run dos2unix against scripts
+    command:
+      dos2unix "{{ item }}"
+    with_items:
+    - '/home/vagrant/.vimrc'
+
+  - name: download scala vim configuration
+    get_url:
+      url=https://raw.githubusercontent.com/derekwyatt/vim-scala/master/syntax/scala.vim
+      dest={{ item.dest }}/{{ item.dir }}/scala.vim
+      mode=0440
+    with_items:
+    - { dir: 'ftdetect', dest: '/home/vagrant/.vim' }
+    - { dir: 'indent', dest: '/home/vagrant/.vim' }
+    - { dir: 'syntax', dest: '/home/vagrant/.vim' }

--- a/ansible/roles/vi/tasks/main.yml
+++ b/ansible/roles/vi/tasks/main.yml
@@ -1,21 +1,21 @@
 ---
   - name: Create vim directory
     file:
-      path=/home/vagrant/{{ item.dir }}
-      state=directory
-      owner=vagrant
-      group=vagrant
-      mode=0775
+      path: "/home/vagrant/{{ item.dir }}"
+      state: directory
+      owner: vagrant
+      group: vagrant
+      mode: 0775
     with_items:
     - { dir: '.vim' }
 
   - name: Creates directory
     file:
-      path=/home/vagrant/.vim/{{ item.dir }}
-      state=directory
-      owner=vagrant
-      group=vagrant
-      mode=0775
+      path: "/home/vagrant/.vim/{{ item.dir }}"
+      state: directory
+      owner: vagrant
+      group: vagrant
+      mode: 0775
     with_items:
     - { dir: 'ftdetect' }
     - { dir: 'indent' }
@@ -23,11 +23,11 @@
 
   - name: copy scripts to workspace
     copy:
-      src={{ item.src }}
-      dest={{ item.dest }}
-      owner=vagrant
-      group=vagrant
-      mode=0775
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
+      owner: vagrant
+      group: vagrant
+      mode: 0775
     with_items:
     - { src: 'vimrc', dest: '/home/vagrant/.vimrc' }
 
@@ -39,9 +39,9 @@
 
   - name: download scala vim configuration
     get_url:
-      url=https://raw.githubusercontent.com/derekwyatt/vim-scala/master/syntax/scala.vim
-      dest={{ item.dest }}/{{ item.dir }}/scala.vim
-      mode=0440
+      url: https://raw.githubusercontent.com/derekwyatt/vim-scala/master/syntax/scala.vim
+      dest: "{{ item.dest }}/{{ item.dir }}/scala.vim"
+      mode: 0440
     with_items:
     - { dir: 'ftdetect', dest: '/home/vagrant/.vim' }
     - { dir: 'indent', dest: '/home/vagrant/.vim' }

--- a/ansible/roles/vscode/tasks/main.yml
+++ b/ansible/roles/vscode/tasks/main.yml
@@ -3,3 +3,16 @@
     apt:
       deb: "https://vscode-update.azurewebsites.net/{{ vscode_version }}/linux-deb-x64/stable"
       autoremove: yes
+
+  - name: install vscode extensions
+    shell: "code --install-extension {{ item }}"
+    become: true
+    become_user: vagrant
+    with_items:
+      - ms-python.python
+      - rogalmic.bash-debug
+      - donjayamanne.githistory
+      - formulahendry.auto-close-tag
+      - humao.rest-client
+      - redhat.vscode-yaml
+      - haaaad.ansible

--- a/development-environment-base.json
+++ b/development-environment-base.json
@@ -53,7 +53,13 @@
         "./ansible/roles/vscode",
         "./ansible/roles/lastpass",
         "./ansible/roles/dotnet",
-        "./ansible/roles/hub"
+        "./ansible/roles/hub",
+        "./ansible/roles/bash_alias",
+        "./ansible/roles/java",
+        "./ansible/roles/lightdm",
+        "./ansible/roles/pip_packages",
+        "./ansible/roles/power_management",
+        "./ansible/roles/vi"
       ],
       "galaxy_file": "requirements.yml"
     },


### PR DESCRIPTION
These were executed needlessly every time we provisioned
the private image. If they are moved to the base image
then the provision of the private image will be faster
and the public image will be better. The only problem
is that we now need to update the base image whenever
we change any of these roles.