### PR TITLE
Add dependencies for vi role

### DIFF
--- a/ansible/roles/vi/meta/main.yml
+++ b/ansible/roles/vi/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: hub }
+  - { role: developer_packages }


### PR DESCRIPTION
Links the fact that vi config relies on vi being installed and the config it sets for hub would need hub installed too