### PR TITLE
Add defaultGrapeConfig.xml file

### DIFF
--- a/ansible/roles/groovy/files/defaultGrapeConfig.xml
+++ b/ansible/roles/groovy/files/defaultGrapeConfig.xml
@@ -1,0 +1,35 @@
+<!--
+
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+
+-->
+<ivysettings>
+  <settings defaultResolver="downloadGrapes"/>
+  <resolvers>
+    <chain name="downloadGrapes" returnFirst="true">
+      <filesystem name="cachedGrapes">
+        <ivy pattern="${user.home}/.groovy/grapes/[organisation]/[module]/ivy-[revision].xml"/>
+        <artifact pattern="${user.home}/.groovy/grapes/[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"/>
+      </filesystem>
+      <ibiblio name="localm2" root="file:${user.home}/.m2/repository/" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true"/>
+      <!-- todo add 'endorsed groovy extensions' resolver here -->
+      <ibiblio name="jcenter" root="https://jcenter.bintray.com/" m2compatible="true"/>
+      <ibiblio name="ibiblio" m2compatible="true"/>
+    </chain>
+  </resolvers>
+</ivysettings>

--- a/ansible/roles/groovy/tasks/main.yml
+++ b/ansible/roles/groovy/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Create .groovy dir
   file:
-    path: /home/vargant/.groovy
+    path: /home/vagrant/.groovy
     state: directory
     owner: vagrant
     group: vagrant

--- a/ansible/roles/groovy/tasks/main.yml
+++ b/ansible/roles/groovy/tasks/main.yml
@@ -28,3 +28,19 @@
   file:
     path: "/opt/groovy/apache-groovy-sdk-{{ groovy_version }}.zip"
     state: absent
+
+- name: Create .groovy dir
+  file:
+    path: /home/vargant/.groovy
+    state: directory
+    owner: vagrant
+    group: vagrant
+    mode: 0775
+
+- name: Copy default config file
+  copy:
+    src: defaultGrapeConfig.xml
+    dest: /home/vagrant/.groovy/defaultGrapeConfig.xml
+    owner: vagrant
+    group: vagrant
+    mode: 0775


### PR DESCRIPTION
In a newly created dev env, "Error grabbing Grapes" occurs as some
dependencies are not available in .m2.

Adding the defaultGrapeConfig.xml file resolve this by customising the
Ivy settings used by Grape.