### PR TITLE
Remove vi length limit for gitcommits

### DIFF
--- a/ansible/roles/vi/files/vimrc
+++ b/ansible/roles/vi/files/vimrc
@@ -22,6 +22,3 @@ set lbr
 
 " Change colorscheme from default to delek
 colorscheme delek
-
-" Limit line length for git commit messages
-au FileType gitcommit set tw=70


### PR DESCRIPTION
No longer required as gerrit isn't used